### PR TITLE
Update API_URL fallback

### DIFF
--- a/common/index.js
+++ b/common/index.js
@@ -20,7 +20,7 @@ const getJSON = async (url) => {
  * @param {string} path - the path you want to append to the api url
  */
 const makeUrl = (path) => {
-  const url = process.env.API_URL || 'https://blockstack-explorer-api.herokuapp.com';
+  const url = process.env.API_URL || 'https://explorer-api.blockstack.org';
   return url + path;
 };
 

--- a/containers/cards/stacks-address.js
+++ b/containers/cards/stacks-address.js
@@ -41,24 +41,8 @@ const StacksAddressCard = ({ address: { address, balance, status, vesting_total:
       </Section>
       <Section pb={4} borderBottom="0">
         <Attribute label="Stacks Address" value={address} />
-        {/* <Attribute
-          label="BTC Address"
-          value={btcAddress}
-          link={{
-            href: {
-              query: {
-                address: btcAddress,
-              },
-              pathname: '/address/single',
-            },
-            as: `/address/${btcAddress}`,
-          }}
-        /> */}
         <Section.Subsection label="Total at this address">
           <Type fontSize={3}>{stacksValue(total)}</Type>
-          {/* <Type fontSize={1} ml={2}>
-            STX
-          </Type> */}
         </Section.Subsection>
         <Section.Subsection label="Cumulative Address Activity" mt={2} />
         <Flex>


### PR DESCRIPTION
### what this does
This removes reference to the previous heroku url for the api in place of the new url.