### PR TITLE
Remove blockchain.info api

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/server/index.js",
+            "env": {
+                "NODE_ENV": "development"
+            }
+        }
+    ]
+}

--- a/common/lib/units.js
+++ b/common/lib/units.js
@@ -1,5 +1,5 @@
 import numeral from 'numeral';
-import BigNumber from 'bignumber.js'
+import BigNumber from 'bignumber.js';
 
 export const formatValue = (v) => {
   const number = parseFloat(v);
@@ -7,10 +7,10 @@ export const formatValue = (v) => {
 };
 
 export const formatLargeNumber = (v, decimals = 0) => {
-  const largeNumber = new BigNumber(v)
-  return largeNumber.toFormat(decimals)
-}
+  const largeNumber = new BigNumber(v);
+  return largeNumber.toFormat(decimals);
+};
 
 export const stacksValue = (value) => `${formatValue(+`${Math.round(`${value * 10e-7}e+7`)}e-7`)} STX`;
 
-export const btcValue = (value) => +`${formatValue(Math.round(`${value * 10e-9}e+9`))}e-9`;
+export const btcValue = (value) => `${formatLargeNumber(new BigNumber(value).shiftedBy(-8), 8)}`;

--- a/containers/cards/address.js
+++ b/containers/cards/address.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Card } from '@components/card/index';
 import { Section } from '@components/section/index';
 import { Attribute } from '@components/attribute';
+import { btcValue } from '@common/lib/units';
 import QRCode from 'qrcode.react';
 
 /**
@@ -15,11 +16,11 @@ const AddressCard = ({ address, ...rest }) => {
         <QRCode level="H" fgColor="currentColor" renderAs="svg" size={156} value={value} />
       </Section>
       <Section showBorder={false} pb={4}>
-        <Attribute label="Address" value={data.address} id="address-card-address" />
-        <Attribute label="Balance" value={`${data.balance} BTC`} />
-        <Attribute label="Total Received" value={`${data.totalReceived} BTC`} />
-        <Attribute label="Total Sent" value={`${data.totalSent} BTC`} />
-        <Attribute label="Total Transactions" value={data.n_tx} />
+        <Attribute label="Address" value={value} id="address-card-address" />
+        <Attribute label="Balance" value={`${btcValue(data.balance)} BTC`} />
+        <Attribute label="Total Received" value={`${btcValue(data.totalReceived)} BTC`} />
+        <Attribute label="Total Sent" value={`${btcValue(data.totalSent)} BTC`} />
+        <Attribute label="Total Transactions" value={data.totalTransactionsCount} />
       </Section>
     </Card>
   );

--- a/containers/cards/transaction.js
+++ b/containers/cards/transaction.js
@@ -49,7 +49,7 @@ const generateAutomaticSections = (data, arr, params) => {
 
 const keys = ['txid', 'blockHash'];
 
-const convertBlockTimeToInt = (blockTime) => new Date(blockTime).getTime() / 1000;
+const convertBlockTimeToInt = (blockTime) => new Date(blockTime).getTime();
 
 /**
  * Some latest transaction data

--- a/containers/lists/names.js
+++ b/containers/lists/names.js
@@ -37,7 +37,7 @@ const NamesList = ({ list, limit, ...rest }) => (
               </Box>
               {time && (
                 <List.Item.Subtitle>
-                  <Time date={time / 1000} />
+                  <Time date={time} />
                 </List.Item.Subtitle>
               )}
             </List.Item>

--- a/containers/lists/single-name-operations.js
+++ b/containers/lists/single-name-operations.js
@@ -4,6 +4,7 @@ import { List } from '@components/list';
 import { ChevronDownIcon, ChevronUpIcon } from 'mdi-react';
 import { Toggle } from 'react-powerplug';
 import Link from 'next/link';
+import moment from 'moment';
 
 const nameOpKeys = ['opcode', 'block_id', 'txid', 'address', 'sender', 'time'];
 
@@ -68,7 +69,14 @@ const NameOperationsList = ({ items, ...rest }) => (
                         </Box>
                         {item[key] ? (
                           <Box maxWidth="100%" overflow="auto">
-                            <Type fontFamily="brand">{item[key]}</Type>
+                            <Type fontFamily="brand">
+                              {key === 'time'
+                                ? moment
+                                    .unix(item[key])
+                                    .utc()
+                                    .format('DD MMMM YYYY HH:MM UTC')
+                                : item[key]}
+                            </Type>
                           </Box>
                         ) : (
                           <Box />

--- a/containers/lists/transactions/names.js
+++ b/containers/lists/transactions/names.js
@@ -20,7 +20,7 @@ const NamesList = ({ names, nextPage }) => (
                 <Box maxWidth="calc(100% - 105px)">
                   <List.Item.Title>{name.name}</List.Item.Title>
                   <List.Item.Subtitle>
-                    <Time date={name.timestamp / 1000} />
+                    <Time date={name.timestamp} />
                   </List.Item.Subtitle>
                 </Box>
                 <Box>

--- a/containers/lists/transactions/subdomains.js
+++ b/containers/lists/transactions/subdomains.js
@@ -20,7 +20,7 @@ const SubdomainsList = ({ subdomains, nextPage }) => (
                 <Box maxWidth="calc(100% - 105px)">
                   <List.Item.Title>{name}</List.Item.Title>
                   <List.Item.Subtitle>
-                    <Time date={subdomain.timestamp / 1000} />
+                    <Time date={subdomain.timestamp} />
                   </List.Item.Subtitle>
                 </Box>
                 <Box>

--- a/containers/lists/tx-list.js
+++ b/containers/lists/tx-list.js
@@ -3,6 +3,7 @@ import { List } from '@components/list/index';
 import { Box } from 'blockstack-ui';
 import { Consumer } from '@pages/_app';
 import { Time } from '@components/time';
+import { btcValue } from '@common/lib/units';
 
 const TxList = ({ transactions, ...rest }) => (
   <Consumer>
@@ -10,8 +11,8 @@ const TxList = ({ transactions, ...rest }) => (
       const txList = transactions || contextTransactions;
       if (!txList) return null;
       return txList
-        .sort((a, b) => new Date(a.time * 1000) < new Date(b.time * 1000))
-        .map(({ txid, valueOut, time, action, value }) => (
+        .sort((a, b) => a.time < b.time)
+        .map(({ txid, time, action, value }) => (
           <List.Item
             href={{
               pathname: '/transaction/single',
@@ -25,7 +26,7 @@ const TxList = ({ transactions, ...rest }) => (
             <Box maxWidth="calc(100% - 105px)">
               <List.Item.Title overflow="auto">
                 {action && <span>{`${action} `}</span>}
-                {`${value || valueOut} BTC`}
+                {`${btcValue(value)} BTC`}
               </List.Item.Title>
               <List.Item.Subtitle overflow="auto">{txid}</List.Item.Subtitle>
             </Box>

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,9 +2,18 @@
   "compilerOptions": {
     "target": "es2017",
     "allowSyntheticDefaultImports": false,
-    "baseUrl": "./",
+    "moduleResolution": "node",
+    "baseUrl": ".",
     "paths": {
-      "@client/*": ["lib/client/*"]
+      "@components/*": ["./components/*"],
+      "@containers/*": ["./containers/*"],
+      "@common/*": ["./common/*"],
+      "@pages/*": ["./pages/*"],
+      "@utils/*": ["./utils/*"],
+      "@stores/*": ["./stores/*"],
+      "@styled/*": ["./styled/*"],
+      "@client/*": ["./lib/client/*"],
+      "@lib/*": ["./lib/*"],
     }
   },
   "exclude": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "heroku-postbuild": "next build"
   },
   "engines": {
-    "node": "^10.15"
+    "node": ">10.15"
   },
   "dependencies": {
     "@awaitjs/express": "^0.1.4",

--- a/pages/address/single.js
+++ b/pages/address/single.js
@@ -12,13 +12,13 @@ class AddressSinglePage extends React.Component {
   static async getInitialProps({ req, query }) {
     const address = req && req.params ? req.params.address : query.address;
     const data = query.data || (await fetchAddress(address));
-    const transactions = data.fullTransactions;
     return {
       address: {
         value: address,
         data,
       },
-      transactions,
+      totalTransactionsCount: data.totalTransactionsCount,
+      transactions: data.transactions,
       nameOperations:
         data.names && data.names.length
           ? data.names.map((name) => ({
@@ -36,7 +36,7 @@ class AddressSinglePage extends React.Component {
     super(props);
     this.state = {
       loadedTxList: props.transactions,
-      hasMoreTx: props.transactions.length < props.address.data.n_tx,
+      hasMoreTx: props.transactions.length < props.totalTransactionsCount,
       pageNum: 0,
     };
   }
@@ -45,14 +45,15 @@ class AddressSinglePage extends React.Component {
     NProgress.start();
     let { loadedTxList, pageNum } = this.state;
     pageNum += 1;
-    const { value, data } = this.props.address;
-    const { fullTransactions } = await fetchAddress(value, pageNum);
-    loadedTxList = loadedTxList.concat(fullTransactions);
+    const { value } = this.props.address;
+    const { totalTransactionsCount } = this.props;
+    const { transactions } = await fetchAddress(value, pageNum);
+    loadedTxList = loadedTxList.concat(transactions);
     this.setState(
       {
         loadedTxList,
         pageNum,
-        hasMoreTx: loadedTxList.length < data.n_tx,
+        hasMoreTx: loadedTxList.length < totalTransactionsCount,
       },
       () => {
         NProgress.done();


### PR DESCRIPTION
https://github.com/blockstack/blockstack-explorer-api/issues/25

Updates to use the new Explorer API bitcoin tx data sources which are not dependent on the blockchain.info API.

This must be used with the corresponding Explorer API PR: https://github.com/blockstack/blockstack-explorer-api/pull/28

* Fixed bug with `time` not displaying for name operations.
* The bitcoin value amounts are now transmitted in satoshis, and formatted for display on the front-end with bignumber.js.
* Fix debugging and intellisense with jsconfig.js / vscode module path mapping.