### PR TITLE
Prevent caching of internal server errors

### DIFF
--- a/common/index.js
+++ b/common/index.js
@@ -7,12 +7,21 @@ import { stacksValue } from '@common/lib/units';
  * @param {string} url - the url you want to fetch
  */
 const getJSON = async (url) => {
-  try {
-    const request = await fetch(url);
-    return request.json();
-  } catch (e) {
-    throw Error(e);
+  const request = await fetch(url);
+  if (!request.ok) {
+    let responseText;
+    try {
+      responseText = await request.text();
+    } catch (error) {
+      // ignore
+    }
+    const error = new Error(`Error ${request.status} fetching ${url}`);
+    error.statusCode = request.status;
+    error.responseBody = responseText;
+    console.error(error);
+    throw error;
   }
+  return request.json();
 };
 
 /**

--- a/pages/_error.js
+++ b/pages/_error.js
@@ -8,9 +8,12 @@ export default class Error extends React.Component {
     if (err) {
       console.error(err);
     }
+    if (res) {
+      res.setHeader('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate');
+    }
     const getStatusCode = () => {
-      if (res) return res.statusCode;
-      if (err) return err.statusCode;
+      if (res && res.statusCode) return res.statusCode;
+      if (err && err.statusCode) return err.statusCode;
       return 500;
     };
     const statusCode = getStatusCode();
@@ -34,13 +37,6 @@ export default class Error extends React.Component {
               Sorry, something seems to have gone wrong.
             </Type>
           )}
-          <Type maxWidth="500px" lineHeight={1.6} textAlign="center" fontSize={3} display="block" my={2}>
-            This explorer only has visibility into confirmed transactions. Please use a BTC explorer like{' '}
-            <a href="https://www.blockchain.com/explorer" target="blank" rel="noopener noreferrer">
-              blockchain.com
-            </a>{' '}
-            to search for unconfirmed transactions.
-          </Type>
           <Box mt={5}>
             <Link href="/" passHref prefetch={false}>
               <Button is="a">Back Home</Button>

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -18,6 +18,9 @@ class SearchPage extends React.Component {
   static async getInitialProps({ res, req, query, err }) {
     const searchTerm = req && req.params ? req.params.search : query.search;
     const statusCode = res && res.statusCode;
+    if (res) {
+      res.setHeader('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate');
+    }
     return {
       ...query,
       statusCode,

--- a/server/index.js
+++ b/server/index.js
@@ -51,6 +51,9 @@ const setup = async () => {
     server.use((req, res, _next) => {
       res.header('Access-Control-Allow-Origin', '*');
       res.header('Access-Control-Allow-Headers', '*');
+      if (!dev) {
+        res.header('Cache-Control', 'max-age=600');
+      }
       _next();
     });
 


### PR DESCRIPTION
Closes #210 

Cloudflare caches all pages for 30 minutes, including error pages that frequently occur when the core node returns internal server errors or timeouts.

With this PR, the server now species the `Cache-Control` header, and error pages are specified as not cached. 